### PR TITLE
feat: enhance color controls and auto template UI

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -597,13 +597,13 @@
 
                     <div class="card">
                         <h3><i class="fas fa-magic"></i> Auto Template</h3>
-                        <div class="form-group">
-                            <label for="auto-arg">Argument</label>
-                            <input type="number" id="auto-arg" value="0">
+                        <div class="form-group" style="display: flex; align-items: center; justify-content: space-between;">
+                            <label for="auto-arg" style="margin-bottom: 0; font-size: 1rem;">Auto Argument</label>
+                            <label class="toggle-switch">
+                                <input type="checkbox" id="auto-arg">
+                                <span class="toggle-slider"></span>
+                            </label>
                         </div>
-                        <button class="btn btn-primary" onclick="sendAutoTemplate(document.getElementById('auto-arg').value)">
-                            <i class="fas fa-play"></i> Apply Auto Template
-                        </button>
                     </div>
                 </div>
             </div>
@@ -712,6 +712,9 @@
                                 <div class="form-group">
                                     <input type="number" id="bg-b" placeholder="B" min="0" max="255" value="0">
                                 </div>
+                                <div class="form-group" style="display: flex; align-items: center;">
+                                    <input type="color" id="bg-color-picker" value="#000000" style="width: 100%; height: 100%; border: 1px solid var(--border-color); border-radius: 0.375rem; cursor: pointer; padding: 0;">
+                                </div>
                             </div>
                             <button class="btn btn-secondary" onclick="sendBgColor(document.getElementById('bg-r').value, document.getElementById('bg-g').value, document.getElementById('bg-b').value)">
                                 <i class="fas fa-fill"></i> Set Background
@@ -729,6 +732,9 @@
                                 </div>
                                 <div class="form-group">
                                     <input type="number" id="fg-b" placeholder="B" min="0" max="255" value="255">
+                                </div>
+                                <div class="form-group" style="display: flex; align-items: center;">
+                                    <input type="color" id="fg-color-picker" value="#ffffff" style="width: 100%; height: 100%; border: 1px solid var(--border-color); border-radius: 0.375rem; cursor: pointer; padding: 0;">
                                 </div>
                             </div>
                             <button class="btn btn-secondary" onclick="sendFgColor(document.getElementById('fg-r').value, document.getElementById('fg-g').value, document.getElementById('fg-b').value)">
@@ -1068,6 +1074,7 @@
         // Refresh interval dropdown handler
         document.getElementById('refresh-interval').addEventListener('change', function() {
             const intervalSeconds = parseInt(this.value);
+            localStorage.setItem('refresh-interval', intervalSeconds);
             startAutoRefresh(intervalSeconds);
         });
 
@@ -1076,9 +1083,6 @@
             console.log('Manual refresh triggered');
             getPixels();
         });
-
-        // Initialize with default 30s refresh
-        startAutoRefresh(30);
 
         // Dark mode functionality
         document.getElementById('dark-mode').addEventListener('change', function() {
@@ -1097,6 +1101,76 @@
             document.documentElement.setAttribute('data-theme', 'dark');
             document.getElementById('dark-mode').checked = true;
         }
+
+        // Load saved refresh interval
+        const savedRefreshInterval = localStorage.getItem('refresh-interval');
+        if (savedRefreshInterval !== null) {
+            const refreshSelect = document.getElementById('refresh-interval');
+            refreshSelect.value = savedRefreshInterval;
+            startAutoRefresh(parseInt(savedRefreshInterval));
+        } else {
+            // Initialize with default 30s refresh if no saved value
+            startAutoRefresh(30);
+        }
+
+        // Color picker functionality
+        function hexToRgb(hex) {
+            const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+            return result ? {
+                r: parseInt(result[1], 16),
+                g: parseInt(result[2], 16),
+                b: parseInt(result[3], 16)
+            } : null;
+        }
+
+        function rgbToHex(r, g, b) {
+            return "#" + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+        }
+
+        function updateRgbFromColorPicker(colorPickerId, rId, gId, bId) {
+            const colorPicker = document.getElementById(colorPickerId);
+            const rInput = document.getElementById(rId);
+            const gInput = document.getElementById(gId);
+            const bInput = document.getElementById(bId);
+
+            colorPicker.addEventListener('input', function() {
+                const rgb = hexToRgb(this.value);
+                if (rgb) {
+                    rInput.value = rgb.r;
+                    gInput.value = rgb.g;
+                    bInput.value = rgb.b;
+                }
+            });
+        }
+
+        function updateColorPickerFromRgb(colorPickerId, rId, gId, bId) {
+            const colorPicker = document.getElementById(colorPickerId);
+            const rInput = document.getElementById(rId);
+            const gInput = document.getElementById(gId);
+            const bInput = document.getElementById(bId);
+
+            const updateColorPicker = function() {
+                const r = parseInt(rInput.value) || 0;
+                const g = parseInt(gInput.value) || 0;
+                const b = parseInt(bInput.value) || 0;
+                colorPicker.value = rgbToHex(r, g, b);
+            };
+
+            rInput.addEventListener('input', updateColorPicker);
+            gInput.addEventListener('input', updateColorPicker);
+            bInput.addEventListener('input', updateColorPicker);
+        }
+
+        // Auto template toggle handler
+        document.getElementById('auto-arg').addEventListener('change', function() {
+            sendAutoTemplate(this.checked ? 'true' : 'false');
+        });
+
+        // Initialize color picker functionality
+        updateRgbFromColorPicker('bg-color-picker', 'bg-r', 'bg-g', 'bg-b');
+        updateRgbFromColorPicker('fg-color-picker', 'fg-r', 'fg-g', 'fg-b');
+        updateColorPickerFromRgb('bg-color-picker', 'bg-r', 'bg-g', 'bg-b');
+        updateColorPickerFromRgb('fg-color-picker', 'fg-r', 'fg-g', 'fg-b');
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Add color picker inputs next to RGB values for background and foreground colors
- Style color pickers to match input field sizing and appearance
- Convert auto-arg from number input to toggle switch sending 'true'/'false' strings
- Remove 'Apply Auto Template' button and apply setting immediately on toggle
- Add localStorage persistence for refresh interval setting
- Implement bidirectional color picker and RGB input synchronization